### PR TITLE
Base evil-custom on normal state

### DIFF
--- a/evil-custom.el
+++ b/evil-custom.el
@@ -30,9 +30,9 @@
 
 ;;;###autoload
 (defun evil-custom-set-keys ()
-  (evil-set-initial-state 'Custom-mode 'motion)
+  (evil-set-initial-state 'Custom-mode 'normal)
 
-  (evil-define-key 'motion custom-mode-map
+  (evil-define-key 'normal custom-mode-map
     ;; motion
     (kbd "<tab>") 'widget-forward
     (kbd "S-<tab>") 'widget-backward


### PR DESCRIPTION
It was based on motion state, but motion state has no way to enter
insert mode and normal mode does.